### PR TITLE
improvement: remove checkout step

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This action allows you to build your monogame project via **msbuild**.
 
-The action first checks out your repo and sets up `dotnet`,`msbuild`, as well as the `mgcb` build tool.
+The action sets up `dotnet`, `msbuild`, and the `mgcb` build tool.
 It then builds the `Content` resources using `mgcb` and then builds the game/project using `msbuild`.
 
 # Usage
@@ -22,6 +22,9 @@ jobs:
     runs-on: windows-latest
 
     steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
       - name: Build android project
         uses: igotinfected-ci/build-monogame@v1
         with:

--- a/action.yml
+++ b/action.yml
@@ -37,9 +37,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout branch
-      uses: actions/checkout@v2
-
     - name: Setup dotnet
       uses: actions/setup-dotnet@v1
       with:


### PR DESCRIPTION
After a bit of looking around I realised that most workflows use `checkout` by default, and that most of the popular actions expect you to do so anyway.

I'm following into those footsteps by removing the checkout action from this custom action.